### PR TITLE
fix: Update GitHub Actions permissions for Claude Code

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Summary
- Update GitHub Actions workflow permissions from read-only to write access
- Allow Claude Code to perform file edits, commits, and PR operations

## Test plan
- [ ] Verify GitHub Actions workflow runs without permission errors
- [ ] Test Claude Code functionality in issues and PRs

🤖 Generated with [Claude Code](https://claude.ai/code)